### PR TITLE
fix col header alignment

### DIFF
--- a/templates/top_movers.html
+++ b/templates/top_movers.html
@@ -11,13 +11,13 @@
               <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-50 uppercase tracking-wider">
                 Info
               </th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-50 uppercase tracking-wider">
+              <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-50 uppercase tracking-wider">
                 Category
               </th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-50 uppercase tracking-wider">
+              <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-50 uppercase tracking-wider">
                 Volume
               </th>
-              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-50 uppercase tracking-wider">
+              <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-50 uppercase tracking-wider">
                 Price
               </th>
 


### PR DESCRIPTION
Price and volume cols were a bit off center due to `text-left`
![image](https://user-images.githubusercontent.com/6494625/106697823-6e98b980-6594-11eb-9b34-8af93fe46e3a.png)
